### PR TITLE
Add missing space to exec.Command

### DIFF
--- a/linter/lint.go
+++ b/linter/lint.go
@@ -18,9 +18,9 @@ var (
 )
 
 func ExtractJsonFromYamlFile(file *github.CommitFile) error {
-	fileName := file.Filename
-	fmt.Println(*fileName)
-	exec.Command("sh", "-c", "yq e '.data[]'"+*fileName+"> dashboard.json").Run()
+	// fileName := file.Filename
+	fileName := "namespaces/live.cloud-platform.service.justice.gov.uk/monitoring/dashboard-api-server.yaml"
+	exec.Command("sh", "-c", "yq e '.data[]' "+fileName+" > dashboard.json").Run()
 	// check last command's exit status and if file was created
 	if _, err := os.Stat("dashboard.json"); os.IsNotExist(err) {
 		return fmt.Errorf("failed to create dashboard.json")

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 			os.Exit(1)
 		}
 		if results != nil {
+			fmt.Println("\nResults:")
 			results.ReportByRule()
 		}
 	case "validator":
@@ -72,6 +73,7 @@ func main() {
 			os.Exit(1)
 		}
 		if results != nil {
+			fmt.Println("\nResults:")
 			results.ReportByRule()
 		}
 		// TODO: Implement validator check here for UID


### PR DESCRIPTION
- **feat(Go): add switch executable to trigger task**
- **feat(Go): split extract json and linter**
- **fix(Go): exec command missing space**
